### PR TITLE
Ethernet mode

### DIFF
--- a/homie/__init__.py
+++ b/homie/__init__.py
@@ -117,7 +117,7 @@ class HomieDevice:
 
     def publish(self, topic, payload, retain=True, qos=1):
         # try reconnect in case it lost connection
-        utils._network_connect()
+        self._network_connect()
 
         if not isinstance(payload, bytes):
             payload = bytes(str(payload), 'utf-8')

--- a/homie/__init__.py
+++ b/homie/__init__.py
@@ -40,13 +40,19 @@ class HomieDevice:
 
         # setup wifi
         utils.setup_network()
-        utils.wifi_connect()
+        self._network_connect()
 
         try:
             self._umqtt_connect()
         except:
             print('ERROR: can not connect to MQTT')
             # self.mqtt.publish = lambda topic, payload, retain, qos: None
+
+    def _network_connect(self):
+        if self.settings.USE_ETHERNET:
+            utils._eth_connect()
+        else:
+            utils.wifi_connect()
 
     def _umqtt_connect(self):
         # mqtt client
@@ -110,8 +116,8 @@ class HomieDevice:
                 self.topic_callbacks[topic](topic, message)
 
     def publish(self, topic, payload, retain=True, qos=1):
-        # try wifi reconnect in case it lost connection
-        utils.wifi_connect()
+        # try reconnect in case it lost connection
+        utils._network_connect()
 
         if not isinstance(payload, bytes):
             payload = bytes(str(payload), 'utf-8')

--- a/homie/utils.py
+++ b/homie/utils.py
@@ -71,9 +71,9 @@ else:
 
 def disable_ap():
     """Disables any Accesspoint"""
-        wlan = network.WLAN(network.AP_IF)
-        wlan.active(False)
-        print('NETWORK: Access Point disabled.')
+    wlan = network.WLAN(network.AP_IF)
+    wlan.active(False)
+    print('NETWORK: Access Point disabled.')
 
 
 def get_unique_id():

--- a/homie/utils.py
+++ b/homie/utils.py
@@ -47,6 +47,7 @@ def _wifi_connect():
         print('NETWORK: Connected, network config: %s' % repr(wlan.ifconfig()))
 
 def _eth_connect():
+    """Connects to Ethernet"""
     if not eth.isconnected():
         print('NETWORK: Activating ethernet...')
         eth.active(True)
@@ -70,9 +71,9 @@ else:
 
 def disable_ap():
     """Disables any Accesspoint"""
-    wlan = network.WLAN(network.AP_IF)
-    wlan.active(False)
-    print('NETWORK: Access Point disabled.')
+        wlan = network.WLAN(network.AP_IF)
+        wlan.active(False)
+        print('NETWORK: Access Point disabled.')
 
 
 def get_unique_id():
@@ -84,12 +85,18 @@ def get_unique_id():
 
 def get_local_ip():
     try:
-        return bytes(network.WLAN(0).ifconfig()[0], 'utf-8')
+        if settings.USE_ETHERNET:
+            return bytes(network.LAN(0).ifconfig()[0], 'utf-8')
+        else:
+            return bytes(network.WLAN(0).ifconfig()[0], 'utf-8')
     except:
         return b'127.0.0.1'
 
 
 def get_local_mac():
+    # NOTE:
+    #   There doesn't seem to be a way to obtain the ethernet's mac address
+    #   Instead, only WLAN mac is used.
     try:
         return ubinascii.hexlify(network.WLAN(0).config('mac'), ':')
     except:

--- a/settings.example.py
+++ b/settings.example.py
@@ -1,4 +1,6 @@
 from homie.utils import get_unique_id
+from machine import Pin
+import network
 
 
 ###
@@ -10,6 +12,22 @@ WIFI_SSID = "YOUR_WIFI_SSID"
 
 # Password for the Wifi
 WIFI_PASSWORD = "YOUR_WIFI_PASSWORD"
+
+###
+# Ethernet settings
+###
+
+# Use ethernet instead of wifi?
+USE_ETHERNET = True
+
+ETHERNET_PHY = network.LAN(
+  id = None,
+  mdc = Pin(23),
+  mdio = Pin(18),
+  power = Pin(17),
+  phy_addr = 0,
+  phy_type = network.PHY_LAN8720
+)
 
 
 ###


### PR DESCRIPTION
Hello! I've made this merge to support ethernet instead of wifi.

-----------------------------------

Before merging, if there is intention to merge (not sure if LAN support is inside this project scope), I'd like to point some things out:

* The setting `ETHERNET_PHY` expects a `network.LAN` object.  This is like this because are there [several settings](https://github.com/loboris/MicroPython_ESP32_psRAM_LoBo/blob/7dd4cba81af4ef682639eb2ed02ef3d33ea5f67a/MicroPython_BUILD/components/micropython/esp32/network_lan.c#L102-L109). I don't like how having an object on the settings looks like, and I am open to discussing what's the best way to handle these settings. **One thing to note:** these settings might vary a lot between platforms, as in, the ESP32 expects the interface to be connected in certain way, which might not be applicable for other boards, who might need extra parameters.

* I only tested this code on the [Olimex ESP32 Ethernet](https://github.com/OLIMEX/ESP32-GATEWAY), since it is the only board I have with ethernet.

* I only tested this code on the [ESP32 LoBo firmware](https://github.com/loboris/MicroPython_ESP32_psRAM_LoBo). It should work under vanilla ESP32 firmware, or other boards, but I did not have other boards at hand to flash and test.

